### PR TITLE
Hotfix - equip defenses calculation

### DIFF
--- a/src/character.js
+++ b/src/character.js
@@ -21,23 +21,7 @@ function updateSecondaryStats(player) {
   player.secondary.manaRegen = Math.floor(player.attributes.intelligence / 2) - 1;
   if (player.secondary.manaRegen < 0) player.secondary.manaRegen = 0; // Ensure no negative regen
 
-  // Add physical defense from all equipped items
-  for (const slot of Object.keys(player.equipment)) {
-    const eq = player.equipment[slot];
-    if (eq && eq.modifiers && typeof eq.modifiers.physicalDefense === "number") {
-      player.secondary.physicalDefense += eq.modifiers.physicalDefense;
-    }
-  }
-
-  // Add magic defense from all equipped items
-  for (const slot of Object.keys(player.equipment)) {
-    const eq = player.equipment[slot];
-    if (eq && eq.modifiers && typeof eq.modifiers.magicDefense === "number") {
-      player.secondary.magicDefense += eq.modifiers.magicDefense;
-    }
-  }
-
-  // Speed is based on dexterity, but can be adjusted as needed
+    // Speed is based on dexterity, but can be adjusted as needed
   player.secondary.speed = Math.floor(player.attributes.dexterity / 1.5) - 5;
   if (player.secondary.speed < 0) player.secondary.speed = 0; // Ensure no negative speed
 
@@ -56,6 +40,23 @@ function updateSecondaryStats(player) {
   // Magic defense is based on intelligence, but can be adjusted as needed
   player.secondary.magicDefense = Math.floor(player.attributes.intelligence * 0.5) - 5;
   if (player.secondary.magicDefense < 0) player.secondary.magicDefense = 0; // Ensure no negative defense
+
+
+  // Add physical defense from all equipped items
+  for (const slot of Object.keys(player.equipment)) {
+    const eq = player.equipment[slot];
+    if (eq && eq.modifiers && typeof eq.modifiers.physicalDefense === "number") {
+      player.secondary.physicalDefense += eq.modifiers.physicalDefense;
+    }
+  }
+
+  // Add magic defense from all equipped items
+  for (const slot of Object.keys(player.equipment)) {
+    const eq = player.equipment[slot];
+    if (eq && eq.modifiers && typeof eq.modifiers.magicDefense === "number") {
+      player.secondary.magicDefense += eq.modifiers.magicDefense;
+    }
+  }
 }
 
 function regenMp() {


### PR DESCRIPTION
Hotfix - Defenses calculations

Changed the order how the defenses are calculated, firstly with the attributes and secondly with the equipment modifiers.